### PR TITLE
Use Amplitude new API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,6 @@ const warn = () => typeof console === 'object' &&
 
 export default () => tap(filterAmplitude, ({ key, payload }, action, store) => {
   typeof window !== 'undefined' && typeof window.amplitude === 'object'
-    ? window.amplitude.logEvent(key, payload)
+    ? window.amplitude.getInstance().logEvent(key, payload)
     : warn()
 })


### PR DESCRIPTION
According to [the docs](https://github.com/amplitude/Amplitude-Javascript#api-changes-and-backwards-compatibility) we should get the Amplitude instance with `getInstance`.