### PR TITLE
Add .npmignore and compile before publishing to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+*.log
+node_modules
+src

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "mkdir -p dist && babel src/index.js --out-file dist/index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The last version of the library was published without compiling it before. 

I added a `prepublish` hook so it builds the app automatically on publishing